### PR TITLE
Add `tabindex="-1"` to the list viewport

### DIFF
--- a/src/lib/VirtualList.svelte
+++ b/src/lib/VirtualList.svelte
@@ -139,6 +139,7 @@
 	bind:offsetHeight={viewport_height}
 	on:scroll={handle_scroll}
 	style="height: {height};"
+	tabindex="-1"
 >
 	<svelte-virtual-list-contents
 		bind:this={contents}


### PR DESCRIPTION
In Firefox, the list viewport is in the tab order, but not in Chrome, so this makes it consistent