### PR TITLE
Allow Svelte 5 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"dist"
 	],
 	"peerDependencies": {
-		"svelte": "^4.0.0"
+		"svelte": "^4.0.0 || ^5.0.0"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^2.0.0",


### PR DESCRIPTION
This component is compatible as-is with Svelte 5, just have to allow let NPM know.